### PR TITLE
Add space after colon automatically

### DIFF
--- a/autoload/csscomplete.vim
+++ b/autoload/csscomplete.vim
@@ -98,9 +98,9 @@ function! csscomplete#CompleteCSS(findstart, base)
 
     for m in s:values
       if m =~? '^'.entered_property
-        call add(res, m . ':')
+        call add(res, m . ': ')
       elseif m =~? entered_property
-        call add(res2, m . ':')
+        call add(res2, m . ': ')
       endif
     endfor
 


### PR DESCRIPTION
This saves a character of typing every time you make a completion.

I guess it's possible this would be undesirable for someone if they preferred no space after the colon (eg `display:none` instead of `display: none`). But from what I've seen the space in between is pretty universal. Could always make this configurable with a global/buffer variable if you don't want to apply it across the board. Let me know if that's the case, I can make a separate PR with that change instead.