### PR TITLE
Fix undefined `b:after` variable

### DIFF
--- a/autoload/csscomplete.vim
+++ b/autoload/csscomplete.vim
@@ -39,12 +39,12 @@ function! csscomplete#CompleteCSS(findstart, base)
   if exists("b:compl_context")
     let line = getline('.')
     let compl_begin = col('.') - 2
-    let after = line[compl_begin:]
+    let b:after = line[compl_begin:]
     let line = b:compl_context
     unlet! b:compl_context
   else
     let line = a:base
-    let after = ''
+    let b:after = ''
   endif
 
   let res = []


### PR DESCRIPTION
This plugin defines a `after` variable but [reads `b:after` later on](https://github.com/othree/csscomplete.vim/blob/f1c7288a4e63b736678dba6fe4f8e825a8a9fd4b/autoload/csscomplete.vim#L758) which causes crashes in rare occurrences. This PR fixes this.

Note that the opposite patch works too, e.g. leaving those 2 lines alone but replacing `if b:after =~? '"'` by `if after =~? '"'` later on. If that makes more sense I'll be happy to update this PR.

Related to https://github.com/vim/vim/pull/8887

Cheers!